### PR TITLE
fix: production needs credentials to be passed as body

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ const client = new ClientCredentials({
     tokenHost: 'https://api.helloasso.com',
     tokenPath: '/oauth2/token',
   },
+  options: {
+    authorizationMethod: 'body',
+  },
 });
 
 // Get an access token


### PR DESCRIPTION
Hi,

Using `ClientCredentials()` as stated previously in the documentation is working in your sandbox environment but not in production. After debugging the HTTP query made, it seems the default usage of `simple-oauth2` is passing credentials as encoded through the header, whereas only `x-www-form-urlencoded` is expected on your production environment (got `401` error all the time).

I didn't test this for the `AuthorizationCode()` client, but maybe it should be reviewed too.

Hope it helps,